### PR TITLE
Escaped < character in bullet 3 of chapter 10 list

### DIFF
--- a/class-05-images-color-text/README.md
+++ b/class-05-images-color-text/README.md
@@ -53,7 +53,7 @@ We'll do code reviews to begin class most days
 
 - p.229: Understanding CSS: Thinking inside the box (!!!)
 - p.230-1: How CSS associates with HTML and affects their display
-- p.235: Linking your CSS file (vs. using a <style> tag)
+- p.235: Linking your CSS file (vs. using a \<style\> tag)
 - pp.237-8: CSS selectors (with VERY handy reference chart)
 - p.239: How CSS rules cascade
 - p.240: Inheritance


### PR DESCRIPTION
the raw '<' character was causing the rest of the html markup to flail.